### PR TITLE
Removed error redirects from docker commands to make debugging easier

### DIFF
--- a/make/stonehenge.mk
+++ b/make/stonehenge.mk
@@ -49,14 +49,14 @@ PHONY += --up-create-network
 --up-create-network:
 ifeq ($(NETWORK_EXISTS),no)
 	$(call step,Create network ${NETWORK_NAME}...)
-	@docker network create ${NETWORK_NAME} && echo "Network created"
+	@docker network create ${NETWORK_NAME} > /dev/null && echo "Network created"
 endif
 
 PHONY += --up-create-volume
 --up-create-volume:
 ifeq ($(SSH_VOLUME_EXISTS),no)
 	$(call step,Create volume ${SSH_VOLUME_NAME}...)
-	@docker volume create ${SSH_VOLUME_NAME} && echo "Volume created"
+	@docker volume create ${SSH_VOLUME_NAME} > /dev/null && echo "Volume created"
 endif
 
 PHONY += start
@@ -70,13 +70,13 @@ ifeq ($(STONEHENGE_EXISTS),no)
 		-v ${SSH_VOLUME_NAME}:/tmp/druid_ssh-agent/ \
 		--env MAILHOG_HOST=mailhog.${DOCKER_DOMAIN} --env TRAEFIK_HOST=traefik.${DOCKER_DOMAIN} \
 		--add-host=host.docker.internal:host-gateway \
-		${STONEHENGE_IMAGE}:${STONEHENGE_TAG} --providers.docker.network="${PREFIX}-network"&& \
+		${STONEHENGE_IMAGE}:${STONEHENGE_TAG} --providers.docker.network="${PREFIX}-network" > /dev/null && \
 		echo "Stonehenge started"
 else
 	@[ "$(shell docker inspect ${CONTAINER_NAME} > /dev/null 2>&1 && echo "yes" || echo "no")" == yes ] && \
 		([ "$(shell docker inspect -f='{{.State.Running}}' ${CONTAINER_NAME})" == true ] && echo "Stonehenge is already running" \
 			|| \
-		 (docker start ${CONTAINER_NAME} && echo "Stonehenge started" && make addkeys))
+		 (docker start ${CONTAINER_NAME} > /dev/null && echo "Stonehenge started" && make addkeys))
 endif
 
 PHONY += --up-post-actions

--- a/make/stonehenge.mk
+++ b/make/stonehenge.mk
@@ -49,14 +49,14 @@ PHONY += --up-create-network
 --up-create-network:
 ifeq ($(NETWORK_EXISTS),no)
 	$(call step,Create network ${NETWORK_NAME}...)
-	@docker network create ${NETWORK_NAME} > /dev/null 2>&1 && echo "Network created"
+	@docker network create ${NETWORK_NAME} && echo "Network created"
 endif
 
 PHONY += --up-create-volume
 --up-create-volume:
 ifeq ($(SSH_VOLUME_EXISTS),no)
 	$(call step,Create volume ${SSH_VOLUME_NAME}...)
-	@docker volume create ${SSH_VOLUME_NAME} > /dev/null 2>&1 && echo "Volume created"
+	@docker volume create ${SSH_VOLUME_NAME} && echo "Volume created"
 endif
 
 PHONY += start
@@ -70,13 +70,13 @@ ifeq ($(STONEHENGE_EXISTS),no)
 		-v ${SSH_VOLUME_NAME}:/tmp/druid_ssh-agent/ \
 		--env MAILHOG_HOST=mailhog.${DOCKER_DOMAIN} --env TRAEFIK_HOST=traefik.${DOCKER_DOMAIN} \
 		--add-host=host.docker.internal:host-gateway \
-		${STONEHENGE_IMAGE}:${STONEHENGE_TAG} --providers.docker.network="${PREFIX}-network" > /dev/null 2>&1 && \
+		${STONEHENGE_IMAGE}:${STONEHENGE_TAG} --providers.docker.network="${PREFIX}-network"&& \
 		echo "Stonehenge started"
 else
 	@[ "$(shell docker inspect ${CONTAINER_NAME} > /dev/null 2>&1 && echo "yes" || echo "no")" == yes ] && \
 		([ "$(shell docker inspect -f='{{.State.Running}}' ${CONTAINER_NAME})" == true ] && echo "Stonehenge is already running" \
 			|| \
-		 (docker start ${CONTAINER_NAME} > /dev/null 2>&1 && echo "Stonehenge started" && make addkeys))
+		 (docker start ${CONTAINER_NAME} && echo "Stonehenge started" && make addkeys))
 endif
 
 PHONY += --up-post-actions


### PR DESCRIPTION
I recently updated from 3.x to 4.x and encountered a few issues and the error messages were suppressed, making debugging pretty frustrating.

At the moment it might fail to an error code with no additional infromation:

```
⚡ Start Stonehenge...

make: *** [make/stonehenge.mk:66: start] Error 125
```

After this change:

```
Error response from daemon: error while removing network: network stonehenge-network id b3a7f7386b8eccba9453623e8f99c3f550fbd9762d60a92baec4cd1bd5afc5fa has active endpoints
[
    {
        "Name": "stonehenge-network",
        "Id": "b3a7f7386b8eccba9453623e8f99c3f550fbd9762d60a92baec4cd1bd5afc5fa",
        "Created": "2021-11-10T11:02:49.509002723+02:00",
        "Scope": "local",
        "Driver": "bridge",
        "EnableIPv6": false,
        "IPAM": {
            "Driver": "default",
            "Options": {},
            "Config": [
                {
                    "Subnet": "192.168.64.0/20",
                    "Gateway": "192.168.64.1"
                }
            ]
        },
        ....
```

```
⚡ Start Stonehenge...

Error response from daemon: network b3a7f7386b8eccba9453623e8f99c3f550fbd9762d60a92baec4cd1bd5afc5fa not found
Error: failed to start containers: stonehenge
make: *** [make/stonehenge.mk:66: start] Error 1
```

```
Warning: No resource found to remove for project "stonehenge".
stonehenge-network
Error response from daemon: remove stonehenge-ssh: volume is in use - [e3078571b8f33d9649ebe7acc0f498eec5f7fff4369b33e3b185f519908425d6]
[
    {
        "CreatedAt": "2022-10-17T09:42:53+03:00",
        "Driver": "local",
        "Labels": {},
        "Mountpoint": "/var/lib/docker/volumes/stonehenge-ssh/_data",
        "Name": "stonehenge-ssh",
        "Options": {},
        "Scope": "local"
    }
]
```
which are really obvious once you see the error message.