### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,9 @@ name: Tests
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
 
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/druidfi/stonehenge/security/code-scanning/1](https://github.com/druidfi/stonehenge/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the workflow's operations. This change ensures that the workflow does not inadvertently gain unnecessary write permissions, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
