### PR TITLE
Fix PowerShell pre-expansion of ~ for WSL paths on Windows

### DIFF
--- a/WSL2.md
+++ b/WSL2.md
@@ -2,24 +2,24 @@
 
 ## Install WSL2 and Docker
 
-- First install WSL2 with instructions: https://docs.microsoft.com/en-us/windows/wsl/install-win10
+- First install WSL2 with instructions: [https://docs.microsoft.com/en-us/windows/wsl/install-win10](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
 - Next in Microsoft Store search and install `Ubuntu LTS` or `Debian`.
-- Then you need to install Docker Desktop. You can download it from https://hub.docker.com/editions/community/docker-ce-desktop-windows
+- Then you need to install Docker Desktop. You can download it from [https://hub.docker.com/editions/community/docker-ce-desktop-windows](https://hub.docker.com/editions/community/docker-ce-desktop-windows)
 - Make sure that you check `Use the WSL2 based engine` option in Docker Desktop settings.
 
 ## Install Stonehenge in PowerShell
 
-```
+```ps1
 wsl sh -c "sudo apt update && sudo apt upgrade && sudo apt install build-essential"
-wsl git clone -b 5.x https://github.com/druidfi/stonehenge.git ~/stonehenge
-wsl make -s -C ~/stonehenge up
+wsl git clone -b 5.x https://github.com/druidfi/stonehenge.git "~/stonehenge"
+wsl make -s -C "~/stonehenge" up
 $WSL_NAME = $(wsl sh -c 'echo $WSL_DISTRO_NAME')
 $WSL_USER = $(wsl whoami)
 Import-Certificate -Filepath \\wsl$\$WSL_NAME\home\$WSL_USER\stonehenge\certs\rootCA.pem -CertStoreLocation cert:\CurrentUser\Root
 ```
 
-### Oneliner with PowerShell (beta):
+### Oneliner with PowerShell (beta)
 
-```
+```ps1
 iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/druidfi/stonehenge/5.x/install.ps1'))
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,9 @@
-$REPO_FOLDER=~/stonehenge
-$REPO_URL=https://github.com/druidfi/stonehenge.git
-$REPO_BRANCH=5.x
 $WSL_NAME = $(wsl sh -c 'echo $WSL_DISTRO_NAME')
 $WSL_USER = $(wsl whoami)
+$REPO_FOLDER="/home/$WSL_USER/stonehenge"
+$REPO_URL="https://github.com/druidfi/stonehenge.git"
+$REPO_BRANCH="5.x"
+
 
 # Install needed packages to WSL
 wsl sh -c "sudo apt update && sudo apt upgrade && sudo apt install build-essential"
@@ -11,7 +12,7 @@ wsl sh -c "sudo apt update && sudo apt upgrade && sudo apt install build-essenti
 wsl git clone -b $REPO_BRANCH $REPO_URL $REPO_FOLDER
 
 # Start Stonehenge
-wsl make -s -C ~/stonehenge up
+wsl make -s -C $REPO_FOLDER up
 
 # Import Stonehenge certificate
 Import-Certificate -Filepath \\wsl$\$WSL_NAME\home\$WSL_USER\stonehenge\certs\rootCA.pem -CertStoreLocation cert:\CurrentUser\Root


### PR DESCRIPTION
## Summary
This PR fixes a Windows PowerShell path expansion issue where `~` may be expanded by PowerShell before being passed to WSL.

## Why this change is needed
On Windows, especially PowerShell 7, `~` can be expanded early to the Windows home path.
As a result, a command like `wsl echo ~/stonehenge` can become `C:Users<win user>/stonehenge` instead of the expected `/home/<wsl user>/stonehenge`.

To prevent this, `~/stonehenge` must be quoted as `"~/stonehenge"` so PowerShell does not pre-expand `~` and WSL receives the intended Linux path expression.

## Changes in this PR
- Updated `install.ps1` to avoid incorrect path handling caused by PowerShell pre-expansion.
- Updated `WSL2.md` documentation to explain the required quoting behavior for `~/...` paths in PowerShell.

## Tested environment
- OS: Windows 11 25H2
- Shell: PowerShell 7.6.2
- WSL2: Ubuntu 26.04

I would greatly appreciate your review when you have a moment. Thank you very much for your time and consideration.